### PR TITLE
Fix autoencoder training script

### DIFF
--- a/src/attention.py
+++ b/src/attention.py
@@ -88,15 +88,15 @@ class CrossAttention(nn.Module):
         self.v_proj = nn.Linear(self.encoder_dim, self.embed_dim)
         self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
         
-    def forward(self, x, enc_inputs, attention_mask=None):
+    def forward(self, x, encoder_inputs, attention_mask=None):
         B, L, D = x.size()
-        Be, Le, De = enc_inputs.size()
+        Be, Le, De = encoder_inputs.size()
         assert Be == B, f"Batch size of encoder inputs {Be} does not match query inputs {B}"
         assert D == self.embed_dim, f"Input dimension {D} does not match embed_dim {self.embed_dim}"
         
         q = self.q_proj(x).view(B, L, self.n_heads, self.head_dim).transpose(1, 2)
-        v = self.v_proj(enc_inputs).view(Be, Le, self.n_heads, self.head_dim).transpose(1, 2)
-        k = self.k_proj(enc_inputs).view(Be, Le, self.n_heads, self.head_dim).transpose(1, 2)
+        v = self.v_proj(encoder_inputs).view(Be, Le, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.k_proj(encoder_inputs).view(Be, Le, self.n_heads, self.head_dim).transpose(1, 2)
         q = self.RoPE(q) # Only apply RoPE to queries
         
         if attention_mask is not None:
@@ -112,7 +112,7 @@ class CrossAttention(nn.Module):
 
 class SlotAttention(nn.Module):
     def __init__(self, incoming_dim, slot_dim, n_heads, n_slots, dropout=0.1, layer_norm_eps=1e-5):
-        super(CrossAttention, self).__init__()
+        super(SlotAttention, self).__init__()
         self.incoming_dim = incoming_dim
         self.n_heads = n_heads
         self.slot_dim = slot_dim
@@ -129,7 +129,8 @@ class SlotAttention(nn.Module):
             max_seq_len=256
         )
         
-        self.q = nn.Parameter(torch.randn(n_slots, self.head_dim)) #Already have projections
+        # Query slots that will attend to the incoming sequence
+        self.q = nn.Parameter(torch.randn(n_slots, self.slot_dim))
         self.k_proj = nn.Linear(self.incoming_dim, self.slot_dim)
         self.v_proj = nn.Linear(self.incoming_dim, self.slot_dim)
         self.out_proj = nn.Linear(self.slot_dim, self.slot_dim)
@@ -149,6 +150,6 @@ class SlotAttention(nn.Module):
             q, k, v,
             attn_mask=attention_mask,
             dropout_p=self.dropout if self.training else 0.0)
-        attn_output = attn_output.transpose(1, 2).contiguous().view(B, L, self.slot_dim)  # [B, L, slot_dim]
+        attn_output = attn_output.transpose(1, 2).contiguous().view(B, self.n_slots, self.slot_dim)  # [B, n_slots, slot_dim]
         attn_output = self.out_proj(attn_output)  # [B, n_heads, L, head_dim]
         return attn_output

--- a/src/train_autoencoder.py
+++ b/src/train_autoencoder.py
@@ -55,7 +55,7 @@ print("Length of tokenizer:", len(tokenizer))
 model = AutoEncoder(
     vocab_size = len(tokenizer),
     embed_dim = 256, 
-    encoder_dim = 512,  # Double embed_dim for simplicity
+    slot_dim = 512,  # Dimension of the slot representations
     ff_dim = 1024,
     n_layers_enc = 4,
     n_layers_dec = 4,


### PR DESCRIPTION
## Summary
- fix variable names in autoencoder training script
- correct slot attention dimensionality
- register output layer in `AutoEncoder`
- adjust cross attention interface

## Testing
- `pytest -q`
- `python src/train_autoencoder.py` *(fails: Couldn't reach 'Salesforce/wikitext' on the Hub)*

------
https://chatgpt.com/codex/tasks/task_e_684348a859fc832c9027db3701271bab